### PR TITLE
Using mkdir -p to minimize errors

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -2,9 +2,8 @@
 
 nohup broadwayd :5 &
 
-mkdir /root/Desktop
-mkdir /root/.config
-mkdir /root/.config/nautilus
+mkdir -p /root/Desktop
+mkdir -p /root/.config/nautilus
 sleep 2
 
 /dock


### PR DESCRIPTION
This cleans up init.sh a tiny bit, removes the error about directories existing when running.